### PR TITLE
Set X-Forwarded-User on proxied request

### DIFF
--- a/oidc.go
+++ b/oidc.go
@@ -175,7 +175,7 @@ func (h *cookieAuthzHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	if isAuthorized(ac.Email, ac.Domain, h.allowEmails, h.allowDomains) {
 		h.debug.Printf("Received authorized request from user=%s of domain=%s at addr=%s for path=%s",
 			ac.Email, ac.Domain, r.RemoteAddr, r.URL.Path)
-		w.Header().Set("X-Forwarded-User", ac.Email)
+		r.Header.Set("X-Forwarded-User", ac.Email)
 		h.next.ServeHTTP(w, r)
 		return
 	} else {


### PR DESCRIPTION
The response sent to the client is receiving the X-Forwarded-User header, but it should be passed to the downstream service so that it can know the user.

Closes #7