### PR TITLE
New feature: add config option to allow passing through the JWT to a downstream service 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,25 @@ client secret. See the [Google developer docs](https://developers.google.com/ide
 
 ## Configuration
 
-| Option             | Default        | Required | Description                                                                                                                                                                       |
-|--------------------|----------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| oidc.clientID      |                | X        | OAuth client ID                                                                                                                                                                   |
-| oidc.clientSecret  |                | X        | OAuth client secret                                                                                                                                                               |
-| oidc.callbackPath  | /oidc/callback |          | The path where the OIDC provider will redirect the user after authenticating.                                                                                                     |
-| oidc.redirectHost  |                |          | Optional host override for the OIDC redirect URI. Use this to configure a single, central redirect URI for multiple subdomains (e.g., `auth.example.com`). Requires `cookie.domain` to be set for cookie sharing. |
-| oidc.prompt        |                |          | A space-delimited, case-sensitive list of prompts to present the user. Possible values are: `none`, `consent`, `select_account`. See [Google's docs](https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1) for more info. |
-| cookie.name        | oidc_auth      |          | Name of the cookie. It can be customized to avoid collisions when running multiple instances of the middleware.                                                                   |
-| cookie.path        | /              |          | You can use this to limit the scope of the cookie to a specific path. Defaults to '/'.                                                                                            |
-| cookie.secret      |                | X        | Secret is the HMAC key for cookie signing, and helps provide integrity protection for cookies.                                                                                    |
-| cookie.duration    | 24h            |          | Validity period for new cookies. Users are granted access for this length of time regardless of changes to user's account in the OIDC provider. Uses the Go time.Duration format. |
-| cookie.insecure    | false          |          | Set to true to omit the `Secure` attribute from cookies.                                                                                                                          |
-| cookie.sameSite    | Lax            |          | SameSite attribute for cookies. Options: `Strict`, `Lax`, `None`. `Lax` provides CSRF protection while allowing cookies on top-level navigation.                                  |
-| cookie.domain      |                |          | Domain attribute for cookies. Use this to share cookies across subdomains (e.g., `.example.com`). Must start with a dot. Required when using `oidc.redirectHost`.                  |
-| authorized.emails  |                | X        | List of allowed email addresses.                                                                                                                                                  |
-| authorized.domains |                | X        | List of allowed domains.                                                                                                                                                          |
-| debug              | false          |          | Enable debug logging to stdout.
+| Option                            | Default               | Required | Description                                                                                                                                                                       |
+|-----------------------------------|-----------------------|----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| oidc.clientID                     |                       | X        | OAuth client ID                                                                                                                                                                   |
+| oidc.clientSecret                 |                       | X        | OAuth client secret                                                                                                                                                               |
+| oidc.callbackPath                 | /oidc/callback        |          | The path where the OIDC provider will redirect the user after authenticating.                                                                                                     |
+| oidc.redirectHost                 |                       |          | Optional host override for the OIDC redirect URI. Use this to configure a single, central redirect URI for multiple subdomains (e.g., `auth.example.com`). Requires `cookie.domain` to be set for cookie sharing. |
+| oidc.prompt                       |                       |          | A space-delimited, case-sensitive list of prompts to present the user. Possible values are: `none`, `consent`, `select_account`. See [Google's docs](https://developers.google.com/identity/protocols/oauth2/web-server#httprest_1) for more info. |
+| cookie.name                       | oidc_auth             |          | Name of the cookie. It can be customized to avoid collisions when running multiple instances of the middleware.                                                                   |
+| cookie.path                       | /                     |          | You can use this to limit the scope of the cookie to a specific path. Defaults to '/'.                                                                                            |
+| cookie.secret                     |                       | X        | Secret is the HMAC key for cookie signing, and helps provide integrity protection for cookies.                                                                                    |
+| cookie.duration                   | 24h                   |          | Validity period for new cookies. Users are granted access for this length of time regardless of changes to user's account in the OIDC provider. Uses the Go time.Duration format. |
+| cookie.insecure                   | false                 |          | Set to true to omit the `Secure` attribute from cookies.                                                                                                                          |
+| cookie.sameSite                   | Lax                   |          | SameSite attribute for cookies. Options: `Strict`, `Lax`, `None`. `Lax` provides CSRF protection while allowing cookies on top-level navigation.                                  |
+| cookie.domain                     |                       |          | Domain attribute for cookies. Use this to share cookies across subdomains (e.g., `.example.com`). Must start with a dot. Required when using `oidc.redirectHost`.                 |
+| authorized.emails                 |                       | X        | List of allowed email addresses.                                                                                                                                                  |
+| authorized.domains                |                       | X        | List of allowed domains.                                                                                                                                                          |
+| headers.jwtPassthrough            | false                 |          | If true, pass the JWT from Google to the downstream service.                                                                                                                      |
+| headers.jwtPassthroughHeaderName  | X-Forwarded-ID-Token  |          | Header name to use for passing the JWT downstream.                                                                                                                                |
+| debug                             | false                 |          | Enable debug logging to stdout.
 
 ## Headers
 
@@ -59,6 +61,14 @@ The resulting access log will contain a `request_X-Forwarded-User` field.
 
 See [Limiting the Fields/Including Headers](https://doc.traefik.io/traefik/observability/access-logs/#limiting-the-fieldsincluding-headers) for more details.
 
+*X-Forwarded-ID-Token*
+
+Disabled by default. If `headers.jwtPassthrough` is set to `true`, the JWT from the OIDC provider will
+be passed through to the downstream client. This can be useful if, for example, the application wants
+to parse JWTs to extract profile data from the claims, such as name or user profile image.
+
+While this is a standard header name to use for this purpose, you can override the default name of the
+JWT passthrough header by also setting `headers.jwtPassthroughHeaderName`.
 
 ## Example config
 
@@ -90,6 +100,8 @@ http:
             clientSecret: fake-secret
           cookie:
             secret: mySecretKey
+          headers: # Pass the JWT to the downstream services
+            jwtPassthrough: true
           authorized:
             emails:
               - name@gmail.com

--- a/oidc.go
+++ b/oidc.go
@@ -42,6 +42,7 @@ type Config struct {
 	OIDC       OIDCConfig
 	Cookie     CookieConfig
 	Authorized AuthorizedConfig
+	Headers    HeadersConfig
 	Debug      bool // Enable debug logging to stdout.
 }
 
@@ -87,6 +88,11 @@ type OIDCConfig struct {
 	Prompt string
 }
 
+type HeadersConfig struct {
+	JwtPassthrough     bool   // If true, the raw JWT from the OIDC provider will be passed downstream in a header.
+	JwtPassthroughHeaderName string // If set, overrides the default header name "X-Forwarded-ID-Token" for passing the raw JWT downstream.
+}
+
 // CreateConfig creates the default plugin configuration.
 func CreateConfig() *Config {
 	return &Config{
@@ -98,6 +104,9 @@ func CreateConfig() *Config {
 			Path:     "/",
 			Duration: "24h",
 			SameSite: "Lax",
+		},
+		Headers: HeadersConfig{
+			JwtPassthrough: false,
 		},
 	}
 }
@@ -135,6 +144,11 @@ func New(_ context.Context, next http.Handler, config *Config, name string) (htt
 		if !strings.HasPrefix(config.Cookie.Domain, ".") {
 			return nil, fmt.Errorf("invalid cookie.domain value %q: must start with a dot (e.g., '.example.com')", config.Cookie.Domain)
 		}
+	}
+
+	// Set the default header name to "X-Forwarded-ID-Token" if passthrough is enabled but no header name override is provided.
+	if config.Headers.JwtPassthrough && config.Headers.JwtPassthroughHeaderName == "" {
+		config.Headers.JwtPassthroughHeaderName = "X-Forwarded-ID-Token"
 	}
 
 	// Require cookie.domain when redirectHost is set (cookies must be shared across subdomains).
@@ -380,6 +394,11 @@ func (h *oidcCallbackHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		h.debug.Printf("failed to build signed cookie: %v", err)
 		http.Error(w, "Internal server error", http.StatusInternalServerError)
 		return
+	}
+
+	// If enabled, pass the JWT downstream in a header
+	if h.config.Headers.JwtPassthrough {
+		w.Header().Set(h.config.Headers.JwtPassthroughHeaderName, token.IDToken)
 	}
 
 	http.Redirect(w, r, csrfCookie.RedirectURL, http.StatusFound)

--- a/oidc_test.go
+++ b/oidc_test.go
@@ -124,12 +124,12 @@ func TestNewAuthCookieFromRequest_MultipleCookies(t *testing.T) {
 
 func TestRedirectURI(t *testing.T) {
 	tests := []struct {
-		name         string
-		callbackPath string
-		redirectHost string
+		name           string
+		callbackPath   string
+		redirectHost   string
 		forwardedProto string
 		forwardedHost  string
-		want         string
+		want           string
 	}{
 		{
 			name:           "default behavior without redirect host",
@@ -260,6 +260,49 @@ func TestConfigValidation(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "valid config with JWT passthrough enabled and default header",
+			config: &Config{
+				OIDC: OIDCConfig{
+					RedirectHost: "auth.example.com",
+				},
+				Cookie: CookieConfig{
+					Secret:   "test-secret",
+					Duration: "24h",
+					SameSite: "Lax",
+					Domain:   ".example.com",
+				},
+				Authorized: AuthorizedConfig{
+					Emails: []string{"user@example.com"},
+				},
+				Headers: HeadersConfig{
+					JwtPassthrough: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "valid config with JWT passthrough enabled and header name override",
+			config: &Config{
+				OIDC: OIDCConfig{
+					RedirectHost: "auth.example.com",
+				},
+				Cookie: CookieConfig{
+					Secret:   "test-secret",
+					Duration: "24h",
+					SameSite: "Lax",
+					Domain:   ".example.com",
+				},
+				Authorized: AuthorizedConfig{
+					Emails: []string{"user@example.com"},
+				},
+				Headers: HeadersConfig{
+					JwtPassthrough:           true,
+					JwtPassthroughHeaderName: "X-Test-Token",
+				},
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -301,10 +344,10 @@ func TestAuthnRedirectHandler_XHRRequests(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		secFetchMode   string
-		wantStatus     int
-		wantRedirect   bool
+		name         string
+		secFetchMode string
+		wantStatus   int
+		wantRedirect bool
 	}{
 		{
 			name:         "navigate mode triggers redirect",


### PR DESCRIPTION
I run some services that can parse out additional data from a valid JWT (in addition to a user's email, things like the first/last name and profile image from their Google profile). Right now, the plugin doesn't send through the actual raw JWT, so I figured I could add that as an option.

I left it disabled by default for safety/compatibility, added a couple of small tests, and updated the doc as well.

Let me know if you have any questions - thanks!